### PR TITLE
http2: fix request reservation when StrictMaxConcurrentStreams is enabled

### DIFF
--- a/http2/transport.go
+++ b/http2/transport.go
@@ -1786,7 +1786,7 @@ func (cs *clientStream) cleanupWriteRequest(err error) {
 	close(cs.donec)
 }
 
-// awaitOpenSlotForStreamLocked waits until len(streams) < maxConcurrentStreams.
+// awaitOpenSlotForStreamLocked waits until len(streams) + pendingResets < maxConcurrentStreams.
 // Must hold cc.mu.
 func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
 	for {
@@ -1800,7 +1800,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
 			return errClientConnUnusable
 		}
 		cc.lastIdle = time.Time{}
-		if cc.currentRequestCountLocked() < int(cc.maxConcurrentStreams) {
+		if int64(len(cc.streams)+cc.pendingResets) < int64(cc.maxConcurrentStreams) {
 			return nil
 		}
 		cc.pendingRequests++

--- a/http2/transport_test.go
+++ b/http2/transport_test.go
@@ -5425,6 +5425,52 @@ func TestIssue67671(t *testing.T) {
 	}
 }
 
+// Issue 70809: when StrictMaxConcurrentStreams enabled ClientConn.ReserveNewRequest() causes stalls in request processing
+func TestIssue70809(t *testing.T) {
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {}, func(s *Server) {
+		s.MaxConcurrentStreams = 1
+	})
+	tr := &Transport{
+		TLSClientConfig:            tlsConfigInsecure,
+		AllowHTTP:                  true,
+		StrictMaxConcurrentStreams: true,
+	}
+
+	var opt RoundTripOpt
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	get := func() int {
+		req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL, nil)
+		res, err := tr.RoundTripOpt(req, opt)
+		if err != nil {
+			t.Error(err)
+		}
+		res.Body.Close()
+		return res.StatusCode
+	}
+
+	if get() != 200 {
+		t.Fatal("first request failed")
+	}
+
+	// Do not dial new connections.
+	opt.OnlyCachedConn = true
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if get() != 200 {
+				t.Errorf("request failed")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
 func TestTransport1xxLimits(t *testing.T) {
 	for _, test := range []struct {
 		name    string


### PR DESCRIPTION
Fix regression introduced in CL 617655. The awaitOpenSlotForStreamLocked() should not take into consideration reserved requests as they have no presence in the connection.

Fixes golang/go#70809

Change-Id: Ia23968189cbdb44dae860a1de9d32700115b28b4